### PR TITLE
Add persistent server storage with MongoDB

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,8 +75,8 @@ Setting up the server
 		# # OR:
 		# pip install uwsgi
 
-  4. Configure the server by changing options in config.py, which is a Flask
-	configuration file.
+  4. Configure the server by adding options to `config.py`.
+       See `config-example.py` for defaults.
 
   5. Start the server:
 

--- a/README.md
+++ b/README.md
@@ -62,10 +62,10 @@ Setting up the server
 		# # OR:
 		# apt-get install python3 python3-pip
 
-  2. Install Flask, and APScheduler:
+  2. Install required Python packages:
 
 		# # You might have to use pip3 if your system defaults to Python 2
-		# pip install APScheduler flask
+		# pip install -r requirements.txt
 
   3. If using in production, install uwsgi and it's python plugin:
 

--- a/README.md
+++ b/README.md
@@ -85,6 +85,17 @@ Setting up the server
 		$ uwsgi -s /tmp/serverlist.sock --plugin python -w server:app --enable-threads
 		$ # Then configure according to http://flask.pocoo.org/docs/deploying/uwsgi/
 
+  7. (optional) Configure the proxy server, if any.  You should make the server
+	load static files directly from the static directory.  Also, `/list`
+	should be served from `list.json`.  Example for nginx:
+
+		root /path/to/server/static;
+		rewrite ^/list$ /list.json;
+		try_files $uri @uwsgi;
+		location @uwsgi {
+			uwsgi_pass ...;
+		}
+
 License
 -------
 

--- a/README.md
+++ b/README.md
@@ -75,10 +75,14 @@ Setting up the server
 		# # OR:
 		# pip install uwsgi
 
-  4. Configure the server by adding options to `config.py`.
-       See `config-example.py` for defaults.
+  4. Install, start, and enable MongoDB on boot:
 
-  5. Start the server:
+		# pacman -S mongodb && systemctl enable mongodb --now
+
+  5. Configure the server by adding options to `config.py`.
+	See `config-example.py` for defaults.
+
+  6. Start the server:
 
 		$ ./server.py
 		$ # Or for production:

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Setting up the webpage
 ----------------------
 
 You will have to install node.js, doT.js and their dependencies to compile
-the serverlist webpage template.
+the server list webpage template.
 
 First install node.js, e.g.:
 
@@ -82,7 +82,7 @@ Setting up the server
 
 		$ ./server.py
 		$ # Or for production:
-		$ uwsgi -s /tmp/serverlist.sock --plugin python -w server:app --enable-threads
+		$ uwsgi -s /tmp/minetest-master.sock --plugin python -w server:app --enable-threads
 		$ # Then configure according to http://flask.pocoo.org/docs/deploying/uwsgi/
 
   7. (optional) Configure the proxy server, if any.  You should make the server

--- a/config-example.py
+++ b/config-example.py
@@ -16,9 +16,6 @@ FILENAME = "list.json"
 # only announce once every 5 minutes, so this should be more than 300.
 PURGE_TIME = 350
 
-# List of banned IP addresses
-BANLIST = []
-
 # Creates server entries if a server sends an 'update' and there is no entry yet.
 # This should only be used to populate the server list after list.json was deleted.
 # This WILL cause problems such as mapgen, mods and privilege information missing from the list

--- a/config-example.py
+++ b/config-example.py
@@ -8,9 +8,6 @@ HOST = "127.0.0.1"
 # Port for development server to listen on
 PORT = 5000
 
-# File to store the JSON server list data in.
-FILENAME = "list.json"
-
 # Amount of time, is seconds, after which servers are removed from the list
 # if they haven't updated their listings.  Note: By default Minetest servers
 # only announce once every 5 minutes, so this should be more than 300.

--- a/config-example.py
+++ b/config-example.py
@@ -1,16 +1,12 @@
 
 # Enables detailed tracebacks and an interactive Python console on errors.
 # Never use in production!
-#DEBUG = True
+DEBUG = False
 
 # Address for development server to listen on
-#HOST = "127.0.0.1"
+HOST = "127.0.0.1"
 # Port for development server to listen on
-#PORT = 5000
-
-# Makes the server more performant at sending static files when the
-# server is being proxied by a server that supports X-Sendfile.
-#USE_X_SENDFILE = True
+PORT = 5000
 
 # File to store the JSON server list data in.
 FILENAME = "list.json"

--- a/config-example.py
+++ b/config-example.py
@@ -1,3 +1,4 @@
+from datetime import timedelta
 
 # Enables detailed tracebacks and an interactive Python console on errors.
 # Never use in production!
@@ -8,13 +9,23 @@ HOST = "127.0.0.1"
 # Port for development server to listen on
 PORT = 5000
 
-# Amount of time, is seconds, after which servers are removed from the list
-# if they haven't updated their listings.  Note: By default Minetest servers
-# only announce once every 5 minutes, so this should be more than 300.
-PURGE_TIME = 350
+# Amount of time after which servers are removed from the list if they haven't
+# updated their listings.  Note: By default Minetest servers only announce
+# once every 5 minutes, so this should be more than that.
+UPDATE_TIME = timedelta(minutes=6)
+
+# Amount of time after which servers are removed from the database if they
+# haven't updated their listings.
+PURGE_TIME = timedelta(days=30)
 
 # Creates server entries if a server sends an 'update' and there is no entry yet.
 # This should only be used to populate the server list after list.json was deleted.
 # This WILL cause problems such as mapgen, mods and privilege information missing from the list
 ALLOW_UPDATE_WITHOUT_OLD = False
+
+# Number of days' data to factor into popularity calculation
+POP_DAYS = 3
+
+# Address of the MongoDB server.  You can use domain sockets on unix.
+MONGO_URI = "mongodb://localhost/minetest-master"
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+APScheduler>=3
+Flask>=0.10
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 APScheduler>=3
 Flask>=0.10
+Flask-PyMongo>=0.3
 

--- a/server.py
+++ b/server.py
@@ -36,9 +36,6 @@ def announce():
 	if ip.startswith("::ffff:"):
 		ip = ip[7:]
 
-	if ip in app.config["BANLIST"]:
-		return "Banned.", 403
-
 	data = request.form["json"] if request.method == "POST" else request.args["json"]
 
 	if len(data) > 5000:

--- a/server.py
+++ b/server.py
@@ -26,7 +26,7 @@ def index():
 def list():
 	# We have to make sure that the list isn't cached,
 	# since the list isn't really static.
-	return send_from_directory(app.static_folder, app.config["FILENAME"],
+	return send_from_directory(app.static_folder, "list.json",
 			cache_timeout=0)
 
 
@@ -336,7 +336,7 @@ class ServerList:
 
 	def load(self):
 		try:
-			with open(os.path.join("static", app.config["FILENAME"]), "r") as fd:
+			with open(os.path.join("static", "list.json"), "r") as fd:
 				data = json.load(fd)
 		except FileNotFoundError:
 			return
@@ -359,7 +359,7 @@ class ServerList:
 			self.maxServers = max(servers, self.maxServers)
 			self.maxClients = max(clients, self.maxClients)
 
-			with open(os.path.join("static", app.config["FILENAME"]), "w") as fd:
+			with open(os.path.join("static", "list.json"), "w") as fd:
 				json.dump({
 						"total": {"servers": servers, "clients": clients},
 						"total_max": {"servers": self.maxServers, "clients": self.maxClients},

--- a/server.py
+++ b/server.py
@@ -10,7 +10,11 @@ sched = BackgroundScheduler(timezone="UTC")
 sched.start()
 
 app = Flask(__name__, static_url_path = "")
-app.config.from_pyfile("config.py")
+
+# Load configuration
+app.config.from_pyfile("config-example.py")  # Use example for defaults
+if os.path.isfile(os.path.join(app.root_path, "config.py")):
+        app.config.from_pyfile("config.py")
 
 
 @app.route("/")


### PR DESCRIPTION
Tested, but still needs some more work.

It would help if there was something to uniqule identify each server -- currently we just have ip and port, but those often change.

Why?: right now mainly just saves extends popularity values, but can be used for things like uptime-as-a-percentage.
