### PR TITLE
Misc. Fixes

### DIFF
--- a/server.py
+++ b/server.py
@@ -349,19 +349,19 @@ class ServerList:
 	def purgeOld(self):
 		with self.lock:
 			self.list = [server for server in self.list if time.time() <= server["update_time"] + app.config["PURGE_TIME"]]
-		self.save()
+			self.save()
 
 	def load(self):
-		try:
-			with open(os.path.join("static", "list.json"), "r") as fd:
-				data = json.load(fd)
-		except FileNotFoundError:
-			return
-
-		if not data:
-			return
-
 		with self.lock:
+			try:
+				with open(os.path.join("static", "list.json"), "r") as fd:
+					data = json.load(fd)
+			except FileNotFoundError:
+				return
+
+			if not data:
+				return
+
 			self.list = data["list"]
 			self.maxServers = data["total_max"]["servers"]
 			self.maxClients = data["total_max"]["clients"]

--- a/server.py
+++ b/server.py
@@ -348,9 +348,7 @@ class ServerList:
 
 	def purgeOld(self):
 		with self.lock:
-			for server in self.list:
-				if server["update_time"] < time.time() - app.config["PURGE_TIME"]:
-					self.list.remove(server)
+			self.list = [server for server in self.list if time.time() <= server["update_time"] + app.config["PURGE_TIME"]]
 		self.save()
 
 	def load(self):

--- a/server.py
+++ b/server.py
@@ -354,7 +354,7 @@ class ServerList:
 	def load(self):
 		with self.lock:
 			try:
-				with open(os.path.join("static", "list.json"), "r") as fd:
+				with open(os.path.join(app.static_folder, "list.json"), "r") as fd:
 					data = json.load(fd)
 			except FileNotFoundError:
 				return
@@ -376,7 +376,7 @@ class ServerList:
 			self.maxServers = max(servers, self.maxServers)
 			self.maxClients = max(clients, self.maxClients)
 
-			list_path = os.path.join(app.root_path, app.static_folder, "list.json")
+			list_path = os.path.join(app.static_folder, "list.json")
 			with open(list_path + "~", "w") as fd:
 				json.dump({
 						"total": {"servers": servers, "clients": clients},


### PR DESCRIPTION
Fix server purging:
The iterate and remove() pattern is broken. In C++ you could quote rules about iterator invalidation here, but with python [i guess this stackoverflow entry](https://stackoverflow.com/questions/1207406/how-to-remove-items-from-a-list-while-iterating/1207427#1207427).
The self.list variable now gets rebuilt, excluding the purged servers, instead of modifier using remove() function.
This should also help theoretical performance, as remove() ran in O(n).

`server["update_time"] < time.time() - app.config["PURGE_TIME"]`
translates to
`not (time.time() <= server["update_time"] + app.config["PURGE_TIME"])`
as follows:

> x < y - z
x + z < y
y > x + z
! (y <= x + z)

Fix locking:
Extends lock scope on two functions.

Improve use of os.path.join:
Computing the path to list.json was done inconsistently. Now app.static_folder is joined with the filename.

in the "os.path.join(app.root_path, app.static_folder, "list.json")" construct, app.root_path and app.static_folder are both absolute paths. [os.path.join](https://docs.python.org/3/library/os.path.html) discards previous paths upon encountering an absolute path. app.root_path therefore had no effect and is now gone.