### PR TITLE
Compatibility fix (string field conversion)

### DIFF
--- a/server.py
+++ b/server.py
@@ -217,8 +217,9 @@ def checkRequest(server):
 		if data[1] == "bool" and type(server[name]).__name__ == "str":
 			server[name] = True if server[name].lower() in ("true", "1") else False
 			continue
-		# clients_max was sent as a string instead of an integer
-		if name == "clients_max" and type(server[name]).__name__ == "str":
+		# Accept strings in integer fields but convert it to an
+		# integer, for minetest.request_http_api interoperability.
+		if data[1] == "int" and type(server[name]).__name__ == "str":
 			server[name] = int(server[name])
 			continue
 		#### End compatibility code ####


### PR DESCRIPTION
This PR addresses this [related forum thread](https://forum.minetest.net/viewtopic.php?f=47&t=19875) .

In lua all numbers are floating point.
An API serializing lua data to JSON does not have sufficient clues to know when an integer (or floating point respectively), field is wanted.

The master-server code places type constraints on received JSON fields.
The master-server code already has a compatibility concept, where a string is accepted, and converted, for the int-valued clients_max field.
This PR extends the compatibility to all int-valued fields.

A client application of master-server, such as a minetest lua mod using minetest.request_http_api, that has difficulties securing the correct serialization for int-valued fields, becomes able to workaround by sending such fields as string.

JSON snippets of port field value for an announce request:
{ "action":"start","port":3000,... }  - works
{ "action":"start","port":3000.0,... } - fails (type does not match)
{ "action":"start","port":"3000",... } - previously fails but now works
