### PR TITLE
More honest points calculations

### DIFF
--- a/server.py
+++ b/server.py
@@ -327,8 +327,11 @@ class ServerList:
 					else:
 						points += 1
 			else:
-				# Old server (1/4 per client)
-				points = server["clients"] / 4
+				for name in server["clients"]:
+					if re.match(r"[A-Z][a-z]{3,}[1-9][0-9]{2,3}", name):
+						points += 1/8
+					else:
+						points += 1
 
 			# Penalize highly loaded servers to improve player distribution.
 			# Note: This doesn't just make more than 80% of max players stop
@@ -345,12 +348,8 @@ class ServerList:
 			points += min(4, server["pop_v"] / 2)
 
 			# -8 for unrealistic max_clients
-			if server["clients_max"] > 200:
+			if server["clients_max"] > 500:
 				points -= 8
-
-			# -8 per second of ping over 0.4s
-			if server["ping"] > 0.4:
-				points -= (server["ping"] - 0.4) * 8
 
 			# Up to -8 for less than an hour of uptime (penalty linearly decreasing)
 			HOUR_SECS = 60 * 60


### PR DESCRIPTION
In continuation to the last discussions. Just a suggestion, let's discuss it here.

**1) Ping.** What a fool came up with it? He considers the time between the server list and the game server, not between the client and the game server! If I am in Russia and the server has a ping of 10ms for me, why should it be lowered? Or if I'm in the USA and the server is in a neighboring state. The problem is even more relevant for Asian players, where the ping to Europe can reach 200ms. I think this is discrimination.
MultiCraft is working on client-side ping. I plan to do PR in Minetest, if it works well.

**2) clients_max.** What is the reason for this limitation? If the developers do not believe in their code and the performance of my hardware, I do not have to suffer from it. I registered 121 players on my server. And a few thousand mobs. Nobody heard about server processors, Postgresql, RAID SSD and good optimization?

<del>**3) guests.** now 1/8 per guest is considered for 0.4.* servers, it would not be fair to consider them full-fledged players for old versions and guests for new ones.
Now players of 0.4.* servers are not considered 1/4 by default. It means nothing in any way, see the code! This is only the server position at http://servers.minetest.net/ !
Client 0.4 will put server 5.0 down the list and vice versa. So this is just for the web page!</del>